### PR TITLE
Fix layout on all client pages

### DIFF
--- a/app/views/clients/edit.html.erb
+++ b/app/views/clients/edit.html.erb
@@ -1,5 +1,12 @@
 <%- model_class = Client -%>
-<div class="page-header">
-  <h1><%=t '.title', :default => [:'helpers.titles.edit', 'Edit %{model}'], :model => model_class.model_name.human.titleize %></h1>
+
+<div class="container">
+  <div class="col-lg-12">
+    <div class="page-header">
+      <h1><%=t '.title', :default => [:'helpers.titles.edit', 'Edit %{model}'], :model => model_class.model_name.human.titleize %>
+      </h1>
+    </div>
+    <%= render :partial => 'form' %>
+  </div>
 </div>
-<%= render :partial => 'form' %>
+

--- a/app/views/clients/index.html.erb
+++ b/app/views/clients/index.html.erb
@@ -1,38 +1,41 @@
 <%- model_class = Client -%>
-<div class="page-header">
-  <h1><%=t '.title', :default => model_class.model_name.human.pluralize.titleize %></h1>
-</div>
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th><%= model_class.human_attribute_name(:id) %></th>
-      <th><%= model_class.human_attribute_name(:name) %></th>
-      <th><%= model_class.human_attribute_name(:description) %></th>
-      <th><%= model_class.human_attribute_name(:created_at) %></th>
-      <th><%=t '.actions', :default => t("helpers.actions") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @clients.each do |client| %>
-      <tr>
-        <td><%= link_to client.id, client_path(client) %></td>
-        <td><%= client.name %></td>
-        <td><%= client.description %></td>
-        <td><%=l client.created_at %></td>
-        <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_client_path(client), :class => 'btn btn-default btn-xs' %>
-          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-                      client_path(client),
-                      :method => :delete,
-                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-                      :class => 'btn btn-xs btn-danger' %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
 
-<%= link_to t('.new', :default => t("helpers.links.new")),
-            new_client_path,
-            :class => 'btn btn-primary' %>
+<div class="container">
+  <div class="col-lg-12">
+    <div class="page-header">
+      <h1><%=t '.title', :default => model_class.model_name.human.pluralize.titleize %>
+      </h1>
+    </div>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th><%= model_class.human_attribute_name(:client_name) %></th>
+          <th><%= model_class.human_attribute_name(:client_description) %></th>
+          <th><%= model_class.human_attribute_name(:created_at) %></th>
+          <th><%=t '.actions', :default => t("helpers.actions") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @clients.each do |client| %>
+          <tr>
+            <td><%= link_to client.name, client_path(client) %></td>
+            <td><%= client.description %></td>
+            <td><%=l client.created_at %></td>
+            <td>
+              <%= link_to t('.edit', :default => t("helpers.links.edit")),
+                edit_client_path(client), :class => 'btn btn-default btn-xs' %>
+              <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
+                client_path(client),
+                :method => :delete,
+                :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
+                :class => 'btn btn-xs btn-danger' %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= link_to t('.new', :default => t("helpers.links.new")),
+      new_client_path,
+      :class => 'btn btn-primary' %>
+  </div>
+</div>

--- a/app/views/clients/new.html.erb
+++ b/app/views/clients/new.html.erb
@@ -1,5 +1,12 @@
 <%- model_class = Client -%>
-<div class="page-header">
-  <h1><%=t '.title', :default => [:'helpers.titles.new', 'New %{model}'], :model => model_class.model_name.human.titleize %></h1>
+
+<div class="container">
+  <div class="col-lg-12">
+    <div class="page-header">
+      <h1><%=t '.title', :default => [:'helpers.titles.new', 'New %{model}'], :model => model_class.model_name.human.titleize %>
+      </h1>
+    </div>
+    <%= render :partial => 'form' %>
+  </div>
 </div>
-<%= render :partial => 'form' %>
+

--- a/app/views/clients/show.html.erb
+++ b/app/views/clients/show.html.erb
@@ -1,21 +1,30 @@
 <%- model_class = Client -%>
-<div class="page-header">
-  <h1><%=t '.title', :default => model_class.model_name.human.titleize %></h1>
+
+<div class="container">
+  <div class="col-lg-12">
+    <div class="page-header">
+      <h1><%=t '.title', :default => model_class.model_name.human.titleize %>
+      </h1>
+    </div>
+    <dl class="dl-horizontal">
+      <dt><strong><%= model_class.human_attribute_name(:name) %>:</strong>
+      </dt>
+      <dd><%= @client.name %>
+      </dd>
+      <dt><strong><%= model_class.human_attribute_name(:description) %>:</strong>
+      </dt>
+      <dd><%= @client.description %>
+      </dd>
+    </dl>
+    <%= link_to t('.back', :default => t("helpers.links.back")),
+      clients_path, :class => 'btn btn-default'  %>
+    <%= link_to t('.edit', :default => t("helpers.links.edit")),
+      edit_client_path(@client), :class => 'btn btn-default' %>
+    <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
+      client_path(@client),
+      :method => 'delete',
+      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
+      :class => 'btn btn-danger' %>
+    </div>
+  </div>
 </div>
-
-<dl class="dl-horizontal">
-  <dt><strong><%= model_class.human_attribute_name(:name) %>:</strong></dt>
-  <dd><%= @client.name %></dd>
-  <dt><strong><%= model_class.human_attribute_name(:description) %>:</strong></dt>
-  <dd><%= @client.description %></dd>
-</dl>
-
-<%= link_to t('.back', :default => t("helpers.links.back")),
-              clients_path, :class => 'btn btn-default'  %>
-<%= link_to t('.edit', :default => t("helpers.links.edit")),
-              edit_client_path(@client), :class => 'btn btn-default' %>
-<%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-              client_path(@client),
-              :method => 'delete',
-              :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-              :class => 'btn btn-danger' %>


### PR DESCRIPTION
Closes https://github.com/Sinetheta/steam-hours/issues/5

Wrapped elements in div classes "container", "col-lg-12", and "page-header".

![client-pages-layout](https://cloud.githubusercontent.com/assets/3332843/6163041/35afb0fe-b241-11e4-87e4-ad9ca4926cfb.jpg)
