### PR TITLE
Update Purchase Orders list-page

### DIFF
--- a/app/views/purchase_orders/index.html.erb
+++ b/app/views/purchase_orders/index.html.erb
@@ -11,20 +11,20 @@
         <tr>
           <th><%= model_class.human_attribute_name(:client) %></th>
           <th><%= model_class.human_attribute_name(:purchase_order) %></th>
-          <th><%= model_class.human_attribute_name(:description) %></th>
           <th><%= model_class.human_attribute_name(:active) %></th>
-          <th><%= model_class.human_attribute_name(:created_on) %></th>
+          <th>Unbilled Entries</th>
+          <th>Billed Entries</th>
           <th><%=t '.actions', :default => t("helpers.actions") %></th>
         </tr>
       </thead>
       <tbody>
         <% @purchase_orders.each do |purchase_order| %>
           <tr>
-            <td><%= purchase_order.client_id %></td>
+            <td><%= purchase_order.client.name %></td>
             <td><%= link_to purchase_order.title, purchase_order_path(purchase_order) %></td>
-            <td><%= purchase_order.description %></td>
             <td><%= purchase_order.active %></td>
-            <td><%=l purchase_order.created_at %></td>
+            <td>*Future Feature*</td>
+            <td>*Future Feature*</td>
             <td>
               <%= link_to t('.edit', :default => t("helpers.links.edit")),
                 edit_purchase_order_path(purchase_order), :class => 'btn btn-default btn-xs' %>

--- a/spec/views/purchase_orders/index.html.erb_spec.rb
+++ b/spec/views/purchase_orders/index.html.erb_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "purchase_orders/index", :type => :view do
     render
     assert_select 'tbody>tr', :count => 2
     expect(rendered).to include(@purchase_orders.first.title)
-    expect(rendered).to include(@purchase_orders.first.description)
     expect(rendered).to include(@purchase_orders.first.active ? 'true': 'false')
   end
 end

--- a/spec/views/purchase_orders/new.html.erb_spec.rb
+++ b/spec/views/purchase_orders/new.html.erb_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe "purchase_orders/new", :type => :view do
 
       assert_select "input#purchase_order_title[name=?]", "purchase_order[title]"
 
-      assert_select "textarea#purchase_order_description[name=?]", "purchase_order[description]"
-
       assert_select "input#purchase_order_active[name=?]", "purchase_order[active]"
     end
   end

--- a/spec/views/purchase_orders/show.html.erb_spec.rb
+++ b/spec/views/purchase_orders/show.html.erb_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "purchase_orders/show", :type => :view do
   it "renders attributes in <p>" do
     render
     expect(rendered).to include(@purchase_order.title)
-    expect(rendered).to include(@purchase_order.description)
     expect(rendered).to include(@purchase_order.active ? 'true': 'false')
   end
 end


### PR DESCRIPTION
Can be crushed in to https://github.com/Sinetheta/steam-hours/commit/f329ce9a4fec677a0aa60b8cefa5eb4ee1d987fe
- Altered spec to pass without description fields
- Added _teasers_
- Removed "created at"
- Changed display of "client ID" to "client name"
