### PR TITLE
Create layout for entry page

### DIFF
--- a/app/assets/stylesheets/theme/_global.scss
+++ b/app/assets/stylesheets/theme/_global.scss
@@ -15,3 +15,7 @@ body {
 .container, .navbar {
   box-shadow: 6px 6px 19px -2px rgba(0,0,0,0.75);
 }
+
+.details-spacing {
+  padding: 8px;
+}

--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -1,27 +1,45 @@
 <%- model_class = Entry -%>
-<div class="page-header">
-  <h1><%=t '.title', :default => model_class.model_name.human.titleize %></h1>
+
+<div class="container">
+  <div class="row">
+    <div class="col-lg-12">
+      <div class="page-header">
+        <h1><%=t '.title', :default => model_class.model_name.human.titleize %></h1>
+      </div>
+      <div class="col-sm-6 details-spacing">
+          <label>Client: </label> <%= @entry.client.name %>
+      </div>
+
+      <div class="col-sm-6 details-spacing">
+          <label>Purchase Order: </label> <%= @entry.purchase_order.title %>
+      </div>
+
+      <div class="col-sm-6 details-spacing">
+          <label>Time In: </label> <%= @entry.start_at %>
+      </div>
+
+      <div class="col-sm-6 details-spacing">
+          <label>Time Out: </label> <%= @entry.end_at %>
+      </div>
+
+      <div class="col-sm-6 details-spacing">
+        <label>Work Performed:</label>
+        <p><%= @entry.description %></p>
+      </div>
+
+      <div class="col-sm-6 details-spacing">
+        <label>Parts Used:</label>
+        <p><%= @entry.parts_used %></p>
+      </div>
+    </div>
+  </div>
+  <%= link_to t('.back', :default => t("helpers.links.back")),
+    entries_path, :class => 'btn btn-default'  %>
+  <%= link_to t('.edit', :default => t("helpers.links.edit")),
+    edit_entry_path(@entry), :class => 'btn btn-default' %>
+  <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
+    entry_path(@entry),
+    :method => 'delete',
+    :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
+    :class => 'btn btn-danger' %>
 </div>
-
-<dl class="dl-horizontal">
-  <dt><strong><%= model_class.human_attribute_name(:start_at) %>:</strong></dt>
-  <dd><%= @entry.start_at %></dd>
-  <dt><strong><%= model_class.human_attribute_name(:end_at) %>:</strong></dt>
-  <dd><%= @entry.end_at %></dd>
-  <dt><strong><%= model_class.human_attribute_name(:description) %>:</strong></dt>
-  <dd><%= @entry.description %></dd>
-  <dt><strong><%= model_class.human_attribute_name(:parts_used) %>:</strong></dt>
-  <dd><%= @entry.parts_used %></dd>
-  <dt><strong><%= model_class.human_attribute_name(:purchase_order_id) %>:</strong></dt>
-  <dd><%= @entry.purchase_order_id %></dd>
-</dl>
-
-<%= link_to t('.back', :default => t("helpers.links.back")),
-              entries_path, :class => 'btn btn-default'  %>
-<%= link_to t('.edit', :default => t("helpers.links.edit")),
-              edit_entry_path(@entry), :class => 'btn btn-default' %>
-<%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-              entry_path(@entry),
-              :method => 'delete',
-              :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-              :class => 'btn btn-danger' %>


### PR DESCRIPTION
The page that shows the details of a specific entry is now styled, and matches the original "form" more closely.

![entry-page](https://cloud.githubusercontent.com/assets/3332843/6274575/4d0e65e6-b82d-11e4-9806-bb751a900abb.jpg)
